### PR TITLE
Feature: Adding list all packages in ChannelSoftware capability

### DIFF
--- a/lib/rhn_satellite/channel_software.rb
+++ b/lib/rhn_satellite/channel_software.rb
@@ -14,6 +14,9 @@ module RhnSatellite
       def list_children(channel_label)
         base.default_call('channel.software.listChildren',channel_label)
       end
+      def list_packages(channel_label)
+        base.default_call('channel.software.listAllPackages',channel_label)
+      end
     end
     
   end


### PR DESCRIPTION
Return an array of hashes.
keys are :
- name
- id
- release
- epoch
- arch_label
- last_modified_date

`{"name"=>"yum", "version"=>"3.2.8",
"release"=>"9.el5_2.1",
"epoch"=>"",
"id"=>5337,
"arch_label"=>"noarch",
"last_modified_date"=>"2008-05-21 17:34:21",
"last_modified"=>"2008-05-21 17:34:21"}`

The documentation can be found at the following address
https://access.redhat.com/knowledge/docs/Red_Hat_Network/API_Documentation/channel/software/ChannelSoftwareHandler.html#listAllPackages

Or locally:
https://$rhnsat/rhn/apidoc/handlers/ChannelSoftwareHandler.jsp#listAllPackages
