### PR TITLE
Added systemgroup functionality for listing active and inactive systems

### DIFF
--- a/lib/rhn_satellite/systemgroup.rb
+++ b/lib/rhn_satellite/systemgroup.rb
@@ -11,6 +11,18 @@ module RhnSatellite
         base.default_call('systemgroup.create',group_name,description)
       end
       
+      def active_systems(group_name)
+        base.default_call('systemgroup.listActiveSystemsInGroup',group_name)
+      end
+
+      def inactive_systems(group_name,days=nil)
+        if days
+          base.default_call('systemgroup.listInactiveSystemsInGroup',group_name,days.to_i)
+        else
+          base.default_call('systemgroup.listInactiveSystemsInGroup',group_name)
+        end
+      end
+      
       def systems(group_name)
         base.default_call('systemgroup.listSystems',group_name)
       end

--- a/spec/unit/rhn_satellite/systemgroup_spec.rb
+++ b/spec/unit/rhn_satellite/systemgroup_spec.rb
@@ -88,6 +88,28 @@ describe RhnSatellite::Systemgroup do
         RhnSatellite::Systemgroup.add_systems('foogroup',['1','2']).should eql(true)
       end
     end
+
+    describe ".active_systems" do
+      it "should list active systems in a group" do
+        RhnSatellite::Connection::Handler.any_instance.expects(:make_call).with('systemgroup.listActiveSystemsInGroup',"token",'foogroup').returns([1])
+        
+        RhnSatellite::Systemgroup.active_systems('foogroup').should eql([1])
+      end
+    end
+
+    describe ".inactive_systems" do
+      it "should list inactive systems in a group" do
+        RhnSatellite::Connection::Handler.any_instance.expects(:make_call).with('systemgroup.listInactiveSystemsInGroup',"token",'foogroup').returns([1])
+        
+        RhnSatellite::Systemgroup.inactive_systems('foogroup').should eql([1])
+      end
+
+      it "should list inactive systems in a group based on given days" do
+        RhnSatellite::Connection::Handler.any_instance.expects(:make_call).with('systemgroup.listInactiveSystemsInGroup',"token",'foogroup',7).returns([1])
+        
+        RhnSatellite::Systemgroup.inactive_systems('foogroup',7).should eql([1])
+      end
+    end
     
     [:systems, :systems_safe].each do |m|
       describe ".#{m.to_s}" do


### PR DESCRIPTION
API Documentation:
https://access.redhat.com/knowledge/docs/en-US/Red_Hat_Network_Satellite/5.4/html/API_Overview/files/handlers/ServerGroupHandler.html#listActiveSystemsInGroup
https://access.redhat.com/knowledge/docs/en-US/Red_Hat_Network_Satellite/5.4/html/API_Overview/files/handlers/ServerGroupHandler.html#listInactiveSystemsInGroup
